### PR TITLE
fix: added missing s to outputs in config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -25,7 +25,7 @@ menu:
       url: tags/
       weight: 10
 
-output:
+outputs:
   home:
     - HTML
     - RSS
@@ -55,13 +55,13 @@ params:
       url: "https://www.linkedin.com/in/maximedelcourt/"
   
   fuseOpts:
-      isCaseSensitive: false
-      shouldSort: true
-      location: 0
-      distance: 1000
-      threshold: 0.4
-      minMatchCharLength: 0
-      keys: ["title", "permalink", "summary", "content"]
+    isCaseSensitive: false
+    shouldSort: true
+    location: 0
+    distance: 1000
+    threshold: 0.4
+    minMatchCharLength: 0
+    keys: ["title", "permalink", "summary", "content"]
 
   services:
     instagram:


### PR DESCRIPTION
`index.json` file is now properly generated, so the search page can now use it for the search.